### PR TITLE
ci: verify branches on pull request, gate deploy to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   build:
@@ -24,6 +25,7 @@ jobs:
     - name: Freeze flask
       run: make freeze
     - name: Push static page
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       run: |
         git config --global user.email "www.kentaro.wada@gmail.com"
         git config --global user.name "Kentaro Wada"


### PR DESCRIPTION
CI previously ran only on push to `main`, where it also deploys to `gh-pages`, so branch changes went unverified until after merge. This adds a `pull_request` trigger and gates the deploy step to `main` pushes, so PRs run `make setup → make lint → make freeze` (on Python 3.14 via uv) without publishing.

## Test plan
- [x] `make lint` and `make freeze` pass locally on Python 3.14
- [x] Deploy step gated with `if: github.ref == 'refs/heads/main' && github.event_name == 'push'`